### PR TITLE
Exposing functionality to be able to check if on shortstop.resolve() protocols got applied.

### DIFF
--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -206,7 +206,7 @@ exports.create = function create(parent) {
         },
 
         didResolve: function() {
-            return this._usedHandler;
+            return (this._usedHandler || false);
         }
 
     };

--- a/test/index.js
+++ b/test/index.js
@@ -23,6 +23,7 @@ test('shortstop', function (t) {
         t.equal(typeof resolver.use, 'function');
         t.equal(typeof resolver.resolve, 'function');
         t.equal(typeof resolver.resolveFile, 'function');
+        t.equal(resolver.didResolve(), false);
         t.end();
     });
 


### PR DESCRIPTION
Needed if the user of shortstop wants to run multiple passes of shortstop.resolve on the same store 
this will be required, if they import a file on the first pass, which can itself have other shortstop handlers.
