### PR TITLE
Ensure type information is not lost.

### DIFF
--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -141,12 +141,14 @@ exports.create = function create(parent) {
 
             self = this;
 
-            if (thing.isObject(data) && !Buffer.isBuffer(data)) {
+            if (thing.isArray(data) || (thing.isObject(data) && Object.getPrototypeOf(data) === Object.prototype)) {
 
                 if (thing.isArray(data)) {
+
                     tasks = data.map(function (val) {
                         return resolve.bind(self, val);
                     });
+
                 } else {
                     tasks = {};
                     Object.keys(data).forEach(function (key) {

--- a/test/index.js
+++ b/test/index.js
@@ -329,17 +329,51 @@ test('shortstop', function (t) {
     });
 
 
-    t.test('preserve buffers', function (t) {
-        var resolver;
+    t.test('preserve types', function (t) {
 
-        resolver = shortstop.create();
-        resolver.resolve({ buffer: new Buffer(0) }, function (err, data) {
-            t.error(err);
-            t.ok(data);
-            t.ok(data.buffer);
-            t.ok(Buffer.isBuffer(data.buffer));
-            t.end()
+        t.test('Buffer', function (t) {
+            var resolver;
+
+            resolver = shortstop.create();
+            resolver.resolve({ buffer: new Buffer(0) }, function (err, data) {
+                t.error(err);
+                t.ok(data);
+                t.ok(data.buffer);
+                t.ok(Buffer.isBuffer(data.buffer));
+                t.end()
+            });
         });
+
+
+        t.test('Date', function (t) {
+            var resolver;
+
+            resolver = shortstop.create();
+            resolver.resolve({ date: new Date() }, function (err, data) {
+                t.error(err);
+                t.ok(data);
+                t.ok(data.date);
+                t.ok(data.date.constructor === Date);
+                t.ok(Object.getPrototypeOf(data.date) !== Object.prototype);
+                t.end()
+            });
+        });
+
+
+        t.test('RegExp', function (t) {
+            var resolver;
+
+            resolver = shortstop.create();
+            resolver.resolve({ regexp: new RegExp('.') }, function (err, data) {
+                t.error(err);
+                t.ok(data);
+                t.ok(data.regexp);
+                t.ok(data.regexp.constructor === RegExp);
+                t.ok(Object.getPrototypeOf(data.regexp) !== Object.prototype);
+                t.end()
+            });
+        });
+
     });
 
 


### PR DESCRIPTION
When data containing complex types is resolved, some type information may be lost. Preserve that for types that are not basic record-like objects, such as Buffer, Date, and RegExp types.
