### PR TITLE
Make resolver filename aware

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ exports.create = function create(parent) {
                 var resolve = this.resolve.bind(this);
 
                 if (isModule(file)) {
-                    resolve(require(file), callback);
+                    resolve(require(file), file, callback);
                     return;
                 }
 
@@ -51,7 +51,7 @@ exports.create = function create(parent) {
 
                     try {
                         data = JSON.parse(data);
-                        resolve(data, callback);
+                        resolve(data, file, callback);
                     } catch (err) {
                         callback(err);
                     }

--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -136,8 +136,13 @@ exports.create = function create(parent) {
          * @param data The data structure to scan
          * @param callback the callback to invoke when processing is complete with the signature `function (err, data)`
          */
-        resolve: function resolve(data, callback) {
+        resolve: function resolve(data, filename, callback) {
             var self, tasks, handler;
+
+            if (!callback) {
+                callback = filename;
+                filename = null;
+            }
 
             self = this;
 
@@ -146,13 +151,13 @@ exports.create = function create(parent) {
                 if (thing.isArray(data)) {
 
                     tasks = data.map(function (val) {
-                        return resolve.bind(self, val);
+                        return resolve.bind(self, val, filename);
                     });
 
                 } else {
                     tasks = {};
                     Object.keys(data).forEach(function (key) {
-                        tasks[key] = resolve.bind(self, data[key]);
+                        tasks[key] = resolve.bind(self, data[key], filename);
                     });
                 }
 
@@ -193,8 +198,10 @@ exports.create = function create(parent) {
                     return handler;
                 });
 
-                tasks.unshift(function init(done) {
+                tasks.unshift(tasks[0].length == 2 ? function init(done) {
                     done(null, data);
+                } : function init(done) {
+                    done(null, data, filename);
                 });
 
                 // Waterfall will *always* resolve asynchronously

--- a/test/index.js
+++ b/test/index.js
@@ -162,6 +162,27 @@ test('shortstop', function (t) {
     });
 
 
+    t.test('resolve with filename', function (t) {
+        var resolver, expected;
+
+        resolver = shortstop.create();
+        resolver.use('foo', foo);
+        resolver.use('bar', function(data, file, cb) {
+            cb(null, file+data);
+        });
+
+        expected = { foo: 'foo:foo', bar: 'bar:bar', baz: false };
+        resolver.resolve(expected, __filename, function  resolve(err, actual) {
+            t.error(err);
+            t.equal(actual.foo, 'foo_foo');
+            t.equal(actual.bar, __filename + 'bar');
+            t.equal(actual.baz, false);
+            t.notEqual(actual, expected);
+            t.end();
+        });
+    });
+
+
     t.test('nested resolve', function (t) {
         var resolver, expected;
 


### PR DESCRIPTION
This allows a resolver to take the filename of the currently processed file into account.