### PR TITLE
chore: restore shorstop 1.0.3 from npm distribution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: node_js
+
 node_js:
-  - "0.10"
   - "0.12"
-  - "4"
-  - "6"
-  - "8"
+  - "0.10"
+  - "iojs"
+  - "iojs-v1.1.0"
+
 script:
-  - "npm run cover"
-  - "npm run lint"
+  - "npm run-script cover"
+  - "npm run-script lint"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,3 @@
-##### v1.0.2 - 20230213
-
-**Security**
-
-- upgrade async module to resolve vulnerability. https://github.com/krakenjs/shortstop/issues/28
-
 ##### v0.0.1 - 2013xxxx
 **Bugs**
 -

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,5 @@
 /*───────────────────────────────────────────────────────────────────────────*\
-│  Copyright (C) 2014 eBay Software Foundation                                │
+│  Copyright (C) 2025 PayPal                                                  │
 │                                                                             │
 │hh ,'""`.                                                                    │
 │  / _  _ \  Licensed under the Apache License, Version 2.0 (the "License");  │

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,5 @@
 /*───────────────────────────────────────────────────────────────────────────*\
-│  Copyright (C) 2023 PayPal                                                  │
+│  Copyright (C) 2014 eBay Software Foundation                                │
 │                                                                             │
 │hh ,'""`.                                                                    │
 │  / _  _ \  Licensed under the Apache License, Version 2.0 (the "License");  │

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-# shortstop
+shortstop
+=========
+
+Lead Maintainer: [Poornima Venkat](https://github.com/pvenkatakrishnan/)
 
 [![Build Status](https://travis-ci.org/krakenjs/shortstop.svg?branch=master)](https://travis-ci.org/krakenjs/shortstop)  
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 shortstop
 =========
 
-Lead Maintainer: [Poornima Venkat](https://github.com/pvenkatakrishnan/)
-
 [![Build Status](https://travis-ci.org/krakenjs/shortstop.svg?branch=master)](https://travis-ci.org/krakenjs/shortstop)  
 
 Sometimes JSON just isn't enough for configuration needs. Occasionally it would be nice to use arbitrary types as values,

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@ We take security very seriously and ask that you follow the following process.
 
 
 ## Contact us
-If you think you may have found a security bug we ask that you privately send the details to DL-PP-Kraken-Js@ebay.com. Please make sure to use a descriptive title in the email.
+If you think you may have found a security bug we ask that you privately send the details to DL-PP-Kraken-Js@paypal.com. Please make sure to use a descriptive title in the email.
 
 
 ## Expectations

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@ We take security very seriously and ask that you follow the following process.
 
 
 ## Contact us
-If you think you may have found a security bug we ask that you privately send the details to DL-PP-Kraken-Js@paypal.com. Please make sure to use a descriptive title in the email.
+If you think you may have found a security bug we ask that you privately send the details to DL-PP-Kraken-Js@ebay.com. Please make sure to use a descriptive title in the email.
 
 
 ## Expectations

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 /*───────────────────────────────────────────────────────────────────────────*\
-│  Copyright (C) 2023 PayPal                                                  │
+│  Copyright (C) 2014 eBay Software Foundation                                │
 │                                                                             │
 │hh ,'""`.                                                                    │
 │  / _  _ \  Licensed under the Apache License, Version 2.0 (the "License");  │
@@ -26,9 +26,7 @@ function isModule(file) {
     // require.resolve will locate a file without a known extension (e.g. txt)
     // and try to load it as javascript. That won't work for this case.
     var ext = path.extname(file);
-    // in order for this to work after deprecation of module.extensions
-    var extensions = {'.js': true, '.json': true, '.node': true}
-    return ext === '' || extensions.hasOwnProperty(ext);
+    return ext === '' || require.extensions.hasOwnProperty(ext);
 }
 
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 /*───────────────────────────────────────────────────────────────────────────*\
-│  Copyright (C) 2014 eBay Software Foundation                                │
+│  Copyright (C) 2025 PayPal                                                  │
 │                                                                             │
 │hh ,'""`.                                                                    │
 │  / _  _ \  Licensed under the Apache License, Version 2.0 (the "License");  │

--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -1,5 +1,5 @@
 /*───────────────────────────────────────────────────────────────────────────*\
-│  Copyright (C) 2014 eBay Software Foundation                                │
+│  Copyright (C) 2025 PayPal                                                  │
 │                                                                             │
 │hh ,'""`.                                                                    │
 │  / _  _ \  Licensed under the Apache License, Version 2.0 (the "License");  │

--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -1,5 +1,5 @@
 /*───────────────────────────────────────────────────────────────────────────*\
-│  Copyright (C) 2023 PayPal                                                  │
+│  Copyright (C) 2014 eBay Software Foundation                                │
 │                                                                             │
 │hh ,'""`.                                                                    │
 │  / _  _ \  Licensed under the Apache License, Version 2.0 (the "License");  │

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shortstop",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Enable use of protocols (such as file:, buffer:, or method:) in configuration files.",
   "main": "index.js",
   "scripts": {
@@ -33,7 +33,7 @@
     "jshint": "~2.4.4"
   },
   "dependencies": {
-    "async": "^3.2.4",
-    "core-util-is": "~1.0.1"
+    "core-util-is": "~1.0.1",
+    "async": "~0.2.10"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shortstop",
-  "version": "1.0.3",
+  "version": "1.0.5",
   "description": "Enable use of protocols (such as file:, buffer:, or method:) in configuration files.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Prior to releasing https://github.com/krakenjs/shortstop/pull/32, we need to get this repository up-to-date with the latest npm distribution. Otherwise, we will re-introduce the same issues introduced in shorstop 1.0.4.

> **Note:** Please note, these changes represent what is already published as shorstop 1.0.5 (latest) and are only a means to sync the source code with what is already published on npm